### PR TITLE
Add page heading to <title>

### DIFF
--- a/sphinx_compas_theme/compas/layout.html
+++ b/sphinx_compas_theme/compas/layout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>COMPAS</title>
+    <title>COMPAS - {{ title|striptags|e }}</title>
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />


### PR DESCRIPTION
To more easily find the right tab when you have multiple tabs with the compas website open.

Tested locally.