### PR TITLE
fetch versions dynamically

### DIFF
--- a/sphinx_compas_theme/compaspkg/layout.html
+++ b/sphinx_compas_theme/compaspkg/layout.html
@@ -66,6 +66,15 @@
             {% endfor %}
           </div>
         </li>
+        {% elif theme_package_old_versions_txt %}
+        <meta id="doc_versions" data-url="{{ theme_package_old_versions_txt }}" data-docs="{{ theme_package_docs }}">
+        <li class="nav-item nav-versions dropdown">
+          <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="bd-versions" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="false">
+            Version
+          </a>
+          <div id="doc_version_list" class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions"></div>
+        </li>
         {% endif %}
         <!-- version -->
         <!-- social -->
@@ -231,6 +240,20 @@
     }).addClass("active");
 
   });
+
+
+  let url = $("#doc_versions").data("url");
+  let docs_site = $("#doc_versions").data("docs");
+
+  if (url) {
+    $.get(url, res=>{
+      let lines = res.match(/[^\r\n]+/g);
+      lines.forEach(version => {
+        $("#doc_version_list").append(`<a class="dropdown-item" href="${docs_site+version}">${version}</a>`);
+      });
+    })
+  }
+
   </script>
   {% block footer %}
   {% endblock %}

--- a/sphinx_compas_theme/compaspkg/layout.html
+++ b/sphinx_compas_theme/compaspkg/layout.html
@@ -242,14 +242,14 @@
   });
 
 
-  let url = $("#doc_versions").data("url");
-  let docs_site = $("#doc_versions").data("docs");
+  var url = $("#doc_versions").data("url");
+  var docs_site = $("#doc_versions").data("docs");
 
   if (url) {
     $.get(url, res=>{
-      let lines = res.match(/[^\r\n]+/g);
+      var lines = res.match(/[^\r\n]+/g);
       lines.forEach(version => {
-        $("#doc_version_list").append(`<a class="dropdown-item" href="${docs_site+version}">${version}</a>`);
+        $("#doc_version_list").append("<a class=\"dropdown-item\" href=\""+ docs_site + version + "\">" + version + "</a>");
       });
     })
   }

--- a/sphinx_compas_theme/compaspkg/theme.conf
+++ b/sphinx_compas_theme/compaspkg/theme.conf
@@ -12,3 +12,4 @@ package_description =
 package_docs = 
 package_repo = 
 package_old_versions = 
+package_old_versions_txt = 


### PR DESCRIPTION
This is a non-breaking change to add a secondary option for getting versions info dynamically from a text url such as  `https://compas.dev/xxx/doc_versions.txt` 

Currently the docs sites of different versions are built purely static, including the versioning dropdown.  Which means the dropdown list of lower versions will not include tags from later version other than latest. 

It would be nice that we simply host a single `doc_versions.txt` at root of `gh-pages` for each projects, which can be auto-updated through Actions. 

And then always have the sites to look at this file to get the list of available versions. 

