### PR TITLE
reflect current version

### DIFF
--- a/sphinx_compas_theme/compaspkg/layout.html
+++ b/sphinx_compas_theme/compaspkg/layout.html
@@ -58,7 +58,7 @@
         <li class="nav-item nav-versions dropdown">
           <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="bd-versions" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
-            Version
+            {{ theme_package_version }}
           </a>
           <div class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions">
             {% for version in theme_package_old_versions %}
@@ -71,7 +71,7 @@
         <li class="nav-item nav-versions dropdown">
           <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="bd-versions" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false">
-            Version
+            {{ theme_package_version }}
           </a>
           <div id="doc_version_list" class="dropdown-menu dropdown-menu-md-right" aria-labelledby="bd-versions"></div>
         </li>


### PR DESCRIPTION
This is to implement @brgcode 's suggestion to have the version text to reflect the current release number directly on the dropdown. 